### PR TITLE
Add java assertions to commands

### DIFF
--- a/src/main/java/panda/command/AlterMarkCommand.java
+++ b/src/main/java/panda/command/AlterMarkCommand.java
@@ -67,6 +67,7 @@ public class AlterMarkCommand extends Command {
      * @throws PandaException if an error occurs during execution.
      */
     public String execute(TaskList tlist, Storage cacheFile) throws PandaException {
+        assert tlist != null;
         if(idx - 1 >= tlist.size()) {
             throw new OutOfBoundsException();
         }

--- a/src/main/java/panda/command/DeleteCommand.java
+++ b/src/main/java/panda/command/DeleteCommand.java
@@ -37,6 +37,7 @@ public class DeleteCommand extends Command {
      * @throws PandaException if an error occurs during deletion.
      */
     public void execute(TaskList tlist, Ui ui, Storage cacheFile) throws PandaException {
+        assert tlist != null;
         if(idx >= tlist.size()) {
             throw new OutOfBoundsException();
         }

--- a/src/main/java/panda/command/FindCommand.java
+++ b/src/main/java/panda/command/FindCommand.java
@@ -47,6 +47,7 @@ public class FindCommand extends Command {
      * @throws PandaException if an error occurs during execution.
      */
     public String execute(TaskList tlist, Storage cacheFile) throws PandaException {
+        assert tlist != null;
         TaskList filteredTasks = tlist.find(fString);
         return filteredTasks.toString();
     }

--- a/src/main/java/panda/command/NewTaskCommand.java
+++ b/src/main/java/panda/command/NewTaskCommand.java
@@ -47,6 +47,7 @@ public class NewTaskCommand extends Command {
      * @throws PandaException if an error occurs during execution.
      */
     public String execute(TaskList tlist, Storage cacheFile) throws PandaException {
+        assert tlist != null;
         tlist.insert(task);
         cacheFile.save(tlist);
         return "Got it. I've added this task:" 

--- a/src/main/java/panda/command/PrintListCommand.java
+++ b/src/main/java/panda/command/PrintListCommand.java
@@ -27,6 +27,7 @@ public class PrintListCommand extends Command {
      * @throws PandaException if an error occurs during execution.
      */
     public String execute(TaskList tlist, Storage cacheFile) throws PandaException {
+        assert tlist != null;
         return tlist.toString();
     }
 


### PR DESCRIPTION
As the program is designed to handle most of the misinputs, the only place java assertions make sense is in the commands.

Executing the commands while passing an uninitialized taskList is a sign that the program is already in a broken state. Thus assertions is used instead of catching for errors.